### PR TITLE
exit function throws error

### DIFF
--- a/www/GAPlugin.js
+++ b/www/GAPlugin.js
@@ -41,7 +41,7 @@
     };
     
     GAPlugin.prototype.exit = function(success, fail) {
-        return cordovaRef.exec(success, fail, 'GAPlugin', 'exitGA');
+        return cordovaRef.exec(success, fail, 'GAPlugin', 'exitGA', []);
     };
  
     cordovaRef.addConstructor(function() {


### PR DESCRIPTION
When calling the Javascript function GAPlugin.exit(…) an exception is thrown because of the class org.apache.cordova.api.CordovaPlugin (Cordova 2.5+) is trying to construct a JSONArray object when the given JSON string is null. This patch adds an empty JSON array to the exec-call to prevent that error.
