### PR TITLE
Check for the existence of Cordova before calling 'addConstructor'

### DIFF
--- a/www/GAPlugin.js
+++ b/www/GAPlugin.js
@@ -44,12 +44,15 @@
         return cordovaRef.exec(success, fail, 'GAPlugin', 'exitGA');
     };
  
-    cordovaRef.addConstructor(function() {
-        if(!window.plugins) {
-            window.plugins = {};
-        }
-        if(!window.plugins.gaPlugin) {
-            window.plugins.gaPlugin = new GAPlugin();
-        }
-    });
+    if (cordovaRef)
+    {
+        cordovaRef.addConstructor(function() {
+            if(!window.plugins) {
+                window.plugins = {};
+            }
+            if(!window.plugins.gaPlugin) {
+                window.plugins.gaPlugin = new GAPlugin();
+            }
+        });
+    }
 })(); /* End of Temporary Scope. */


### PR DESCRIPTION
If you are using Sencha Touch or another HTML5 framework, and do most of your testing in the browser, it is helpful not to throw an exception if Cordova isn't present.
