### PR TITLE
set appVersion on iOS

### DIFF
--- a/src/ios/GAPlugin.m
+++ b/src/ios/GAPlugin.m
@@ -23,6 +23,8 @@
     //[GAI sharedInstance].debug = YES;
     // Create tracker instance.
     [[GAI sharedInstance] trackerWithTrackingId:accountID];
+    // Set the appVersion equal to the CFBundleVersion
+    [GAI sharedInstance].defaultTracker.appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
     inited = YES;
     
     [self successWithMessage:[NSString stringWithFormat:@"initGA: accountID = %@; Interval = %d seconds",accountID, dispatchPeriod] toID:callbackId];


### PR DESCRIPTION
The google analytics SDK no longer sets the appVersion automatically on iOS.  To match the android behavior, I set the appVersion equal to the CFBunbleVersion on initGA.
